### PR TITLE
Updated copyright and comments in tests.

### DIFF
--- a/test262/key-value/map/append-new-values-normalizes-zero-key.js
+++ b/test262/key-value/map/append-new-values-normalizes-zero-key.js
@@ -2,7 +2,7 @@
 // Copyright (C) 2024 Jonas Haukenes. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-map.prototype.getOrInsert
+esid: pending
 description: >
   Append a new value in the map normalizing +0 and -0.
 info: |
@@ -25,3 +25,5 @@ assert.sameValue(map.get(0), 42);
 map = new Map();
 map.getOrInsert(+0, 43);
 assert.sameValue(map.get(0), 43);
+
+reportCompare(0, 0);

--- a/test262/key-value/map/append-new-values.js
+++ b/test262/key-value/map/append-new-values.js
@@ -2,7 +2,7 @@
 // Copyright (C) 2024 Jonas Haukenes. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-map.prototype.getOrInsert
+esid: pending
 description: >
   Append a new value as the last element of entries.
 info: |
@@ -47,3 +47,5 @@ assert.sameValue(result.key, null);
 result = results.pop();
 assert.sameValue(result.value, 2);
 assert.sameValue(result.key, s);
+
+reportCompare(0, 0);

--- a/test262/key-value/map/append-value-if-key-is-not-present-different-key-types.js
+++ b/test262/key-value/map/append-value-if-key-is-not-present-different-key-types.js
@@ -2,7 +2,7 @@
 // Copyright (C) 2024 Sune Eriksson Lianes. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-map.prototype.getOrInsert
+esid: pending
 description: >
   Inserts the value for the specified key on different types, when key not present.
 info: |
@@ -45,3 +45,5 @@ assert.sameValue(map.get(item), 5);
 item = undefined;
 map.getOrInsert(item, 6);
 assert.sameValue(map.get(item), 6);
+
+reportCompare(0, 0);

--- a/test262/key-value/map/does-not-have-mapdata-internal-slot-set.js
+++ b/test262/key-value/map/does-not-have-mapdata-internal-slot-set.js
@@ -2,7 +2,7 @@
 // Copyright (C) 2024 Sune Eriksson Lianes. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-map.prototype.getOrInsert
+esid: pending
 description: >
   Throws a TypeError if `this` is a Set Object
 info: |
@@ -23,3 +23,5 @@ assert.throws(TypeError, function () {
   var map = new Map();
   map.getOrInsert.call(new Set(), 1, 1);
 });
+
+reportCompare(0, 0);

--- a/test262/key-value/map/does-not-have-mapdata-internal-slot-weakmap.js
+++ b/test262/key-value/map/does-not-have-mapdata-internal-slot-weakmap.js
@@ -2,7 +2,7 @@
 // Copyright (C) 2024 Sune Eriksson Lianes. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-map.prototype.getOrInsert
+esid: pending
 description: >
   Throws a TypeError if `this` is a WeakMap object.
 info: |
@@ -23,3 +23,5 @@ assert.throws(TypeError, function() {
   var map = new Map();
   map.getOrInsert.call(new WeakMap(), 1, 1);
 });
+
+reportCompare(0, 0);

--- a/test262/key-value/map/does-not-have-mapdata-internal-slot.js
+++ b/test262/key-value/map/does-not-have-mapdata-internal-slot.js
@@ -2,7 +2,7 @@
 // Copyright (C) 2024 Sune Eriksson Lianes. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-map.prototype.getOrInsert
+esid: pending
 description: >
     Throws a TypeError if `this` object does not have a [[MapData]] internal slot.
 info: |
@@ -30,3 +30,5 @@ assert.throws(TypeError, function () {
 assert.throws(TypeError, function () {
     map.getOrInsert.call({}, 1, 1);
 });
+
+reportCompare(0, 0);

--- a/test262/key-value/map/getOrInsert.js
+++ b/test262/key-value/map/getOrInsert.js
@@ -2,7 +2,7 @@
 // Copyright (C) 2024 Jonas Haukenes. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-map.prototype.getOrInsert
+esid: pending
 description: >
   Property type and descriptor.
 info: |
@@ -24,3 +24,5 @@ verifyProperty(Map.prototype, 'getOrInsert', {
   enumerable: false,
   configurable: true,
 });
+
+reportCompare(0, 0);

--- a/test262/key-value/map/length.js
+++ b/test262/key-value/map/length.js
@@ -2,7 +2,7 @@
 // Copyright (C) 2024 Jonas Haukenes. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-map.prototype.getOrInsert
+esid: pending
 description: >
   Map.prototype.getOrInsert.length value and descriptor.
 info: |
@@ -19,3 +19,5 @@ verifyProperty(Map.prototype.getOrInsert, "length", {
   enumerable: false,
   configurable: true
 });
+
+reportCompare(0, 0);

--- a/test262/key-value/map/name.js
+++ b/test262/key-value/map/name.js
@@ -2,7 +2,7 @@
 // Copyright (C) 2024 Jonas Haukenes. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-map.prototype.getOrInsert
+esid: pending
 description: >
   Map.prototype.getOrInsert.name value and descriptor.
 info: |
@@ -19,3 +19,5 @@ verifyProperty(Map.prototype.getOrInsert, "name", {
   enumerable: false,
   configurable: true
 });
+
+reportCompare(0, 0);

--- a/test262/key-value/map/not-a-constructor.js
+++ b/test262/key-value/map/not-a-constructor.js
@@ -3,7 +3,7 @@
 // This code is governed by the BSD license found in the LICENSE file.
 
 /*---
-esid: sec-ecmascript-standard-built-in-objects
+esid: pending
 description: >
   Map.prototype.getOrInsert does not implement [[Construct]], is not new-able
 info: |
@@ -27,3 +27,5 @@ assert.sameValue(isConstructor(Map.prototype.getOrInsert), false, 'isConstructor
 assert.throws(TypeError, () => {
   let m = new Map(); new m.getOrInsert();
 });
+
+reportCompare(0, 0);

--- a/test262/key-value/map/returns-value-if-key-is-not-present-different-key-types.js
+++ b/test262/key-value/map/returns-value-if-key-is-not-present-different-key-types.js
@@ -38,3 +38,5 @@ assert.sameValue(map.getOrInsert(item, 5), 5);
 
 item = undefined;
 assert.sameValue(map.getOrInsert(item, 6), 6);
+
+reportCompare(0, 0);

--- a/test262/key-value/map/returns-value-if-key-is-present-different-key-types.js
+++ b/test262/key-value/map/returns-value-if-key-is-present-different-key-types.js
@@ -53,3 +53,5 @@ item = undefined;
 map.set(item, 6);
 assert.sameValue(map.get(item), map.getOrInsert(item, 7));
 assert.sameValue(6, map.getOrInsert(item, 7));
+
+reportCompare(0, 0);

--- a/test262/key-value/map/returns-value-normalized-zero-key.js
+++ b/test262/key-value/map/returns-value-normalized-zero-key.js
@@ -2,7 +2,7 @@
 // Copyright (C) 2024 Jonas Haukenes. All rights reserved.
 // This code is governed by the BSD license found in the LICENSE file.
 /*---
-esid: sec-map.prototype.getOrInsert
+esid: pending
 description: >
   Returns the value from the specified key normalizing +0 and -0.
 info: |
@@ -22,3 +22,5 @@ assert.sameValue(map.getOrInsert(-0, 1), 42);
 map = new Map();
 map.set(-0, 43);
 assert.sameValue(map.getOrInsert(+0, 1), 43);
+
+reportCompare(0, 0);

--- a/test262/key-value/map/this-not-object-throw.js
+++ b/test262/key-value/map/this-not-object-throw.js
@@ -39,3 +39,5 @@ assert.throws(TypeError, function () {
 assert.throws(TypeError, function () {
     m.getOrInsert.call(Symbol(), 1, 1);
 });
+
+reportCompare(0, 0);


### PR DESCRIPTION
Added more tests, and changed name of one test.
Removed `reportCompare(0, 0);` as it seems unnecessary and crashes the testrunner in V8.